### PR TITLE
Generate unique external ids

### DIFF
--- a/lib/importers/schema_dot_org_data.rb
+++ b/lib/importers/schema_dot_org_data.rb
@@ -24,7 +24,7 @@ class SchemaDotOrgData
       inactive = false
       days_remaining = 0 if days_remaining < 0 || start_date > end_date || inactive
       entry = {type: 'position_opening', source: source, tags: ["federal", source.downcase.gsub(/ /, "_")]}
-      entry[:external_id] = job_posting.id || job_posting.properties["url"]
+      entry[:external_id] = rand().to_s 
       entry[:locations] = process_locations(job_posting)
       if entry[:locations]
         entry[:locations] = [] if entry[:locations].size >= CATCHALL_THRESHOLD

--- a/lib/importers/schema_dot_org_json_data.rb
+++ b/lib/importers/schema_dot_org_json_data.rb
@@ -22,7 +22,7 @@ class SchemaDotOrgJsonData
     inactive = false
     days_remaining = 0 if days_remaining < 0 || start_date > end_date || inactive
     entry = {type: 'position_opening', source: @source, tags: %w(private)}
-    entry[:external_id] = nil
+    entry[:external_id] = rand().to_s 
     entry[:locations] = process_locations(job)
     if entry[:locations]
       entry[:locations] = [] if entry[:locations].size >= CATCHALL_THRESHOLD


### PR DESCRIPTION
I think job posts need a unique external id -- and hence a unique doc id-- to be placed in the index.  Will need to check this once we get it on staging.  @greggersh please review when you can.
