### PR TITLE
Use ENV var to specify a different write index

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,4 +1,5 @@
 module Elasticsearch
   es_config = (YAML.load_file("#{Rails.root}/config/elasticsearch.yml") || {})[Rails.env]
-  INDEX_NAME = es_config && es_config['index_name'].present? ? es_config['index_name'].freeze : "#{Rails.env}:jobs".freeze
+  INDEX_NAME = es_config && es_config['index_name'].present? ? es_config['index_name'].freeze : "#{Rails.env}:jobs:head".freeze
+  WRITE_INDEX_NAME = ENV['BONSAI_WRITE'] || INDEX_NAME
 end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   es_config = (YAML.load_file("#{Rails.root}/config/elasticsearch.yml") || {})[Rails.env]
   INDEX_NAME = es_config && es_config['index_name'].present? ? es_config['index_name'].freeze : "#{Rails.env}:jobs:head".freeze
-  WRITE_INDEX_NAME = ENV['BONSAI_WRITE'] || INDEX_NAME
+  WRITE_INDEX_NAME = ENV['BONSAI_WRITE'].presence || INDEX_NAME
 end

--- a/spec/models/position_opening_spec.rb
+++ b/spec/models/position_opening_spec.rb
@@ -415,7 +415,37 @@ describe PositionOpening do
         end
         position_openings.results.first[:locations].should be_nil
       end
+      
+    end
 
+    context 'multiple index' do
+      before do
+        @old_index = PositionOpening.index_name
+        @new_index = PositionOpening.index_name('test:jobs:dupe')
+        PositionOpening.import([position_opening])
+      end
+
+      it 'should index to both' do
+        position_openings = Tire.search 'test:jobs:head' do
+          query { all }
+        end
+        expect(position_openings.results.size).to eq(1)
+
+        position_openings = Tire.search 'test:jobs:dupe' do
+          query { all }
+        end
+        expect(position_openings.results.size).to eq(1)
+      end
+
+      it 'should route searches to the read index' do
+        PositionOpening.delete_search_index
+        expect(PositionOpening.search_for.size).to eq(1)
+      end
+      
+      after do
+        PositionOpening.delete_search_index
+        PositionOpening.index_name(@old_index)
+      end
     end
   end
 

--- a/spec/models/position_opening_spec.rb
+++ b/spec/models/position_opening_spec.rb
@@ -392,7 +392,7 @@ describe PositionOpening do
       Geoname.should_receive(:geocode).with(location: 'Washington', state: 'DC').and_return({lat: 23.45, lon: -12.34})
       Geoname.should_receive(:geocode).with(location: 'Maui Island', state: 'HI').and_return({lat: 45.67, lon: -13.31})
       PositionOpening.import([position_opening])
-      position_openings = Tire.search 'test:jobs' do
+      position_openings = Tire.search 'test:jobs:head' do
         query { all }
       end
       position_openings.results.first[:locations][0][:geo].to_hash.should == {lat: 12.34, lon: -23.45}
@@ -410,7 +410,7 @@ describe PositionOpening do
 
       it 'should leave locations empty' do
         PositionOpening.import([position_opening_no_locations])
-        position_openings = Tire.search 'test:jobs' do
+        position_openings = Tire.search 'test:jobs:head' do
           query { all }
         end
         position_openings.results.first[:locations].should be_nil


### PR DESCRIPTION
This allows us to use an ENV var to specify an additional write index to index to.  If we change mappings, then set the ENV var, the new index will be created with the new mappings and will start being populated when things are indexed.  If we also use an index alias to search by, we can also switch to the new index atomically.
