### PR TITLE
Remove failing HTTP request

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -62,11 +62,6 @@ class Query
       self.location = Location.new(location_str)
       query.gsub!(location_str, '')
     end
-    if self.organization_id.nil? && (possible_org = extract_possible_org(query))
-      if (self.organization_id = Agencies.find_organization_id(possible_org))
-        query.gsub!(possible_org, '')
-      end
-    end
     query.gsub(/\b#{JOB_KEYWORD_TOKENS}\b/, '').squish
   end
 


### PR DESCRIPTION
These removed lines were [calling a method](https://github.com/department-of-veterans-affairs/jobs_api/blob/va-jobs/lib/agencies.rb) that was trying to access http://search.usa.gov/api/v1/agencies/search, which is no longer a supported API.  This HTTP request returns a 404 after 10 seconds, meaning this if statement would always fail (and take 10 seconds doing so).  This change should substantially speed up our queries without changing what is actually executed. 
